### PR TITLE
Add `ReadableStream.pull()` and queuing strategies

### DIFF
--- a/test/web.js
+++ b/test/web.js
@@ -1,5 +1,9 @@
 const test = require('brittle')
-const { ReadableStream } = require('../web')
+const {
+  ReadableStream,
+  CountQueuingStrategy,
+  ByteLengthQueuingStrategy
+} = require('../web')
 
 test('basic', async (t) => {
   t.plan(2)
@@ -123,7 +127,7 @@ test('only trigger pull after start is finished', async (t) => {
   })
 })
 
-test('CountQueuingStrategy', async (t) => {
+test('count queuing strategy', async (t) => {
   t.plan(7)
 
   let loop = 0
@@ -185,7 +189,7 @@ test('custom high water mark', async (t) => {
   )
 })
 
-test('ByteLengthQueuingStrategy', async (t) => {
+test('byte length queuing strategy', async (t) => {
   t.plan(7)
 
   let loop = 0

--- a/test/web.js
+++ b/test/web.js
@@ -2,12 +2,14 @@ const test = require('brittle')
 const { ReadableStream } = require('../web')
 
 test('basic', async (t) => {
-  t.plan(1)
+  t.plan(2)
 
   const read = []
 
   const stream = new ReadableStream({
     start(controller) {
+      t.is(controller.desiredSize, 1)
+
       controller.enqueue(1)
       controller.enqueue(2)
       controller.enqueue(3)
@@ -48,6 +50,8 @@ test('cancel', async (t) => {
 })
 
 test('from', async (t) => {
+  t.plan(2)
+
   async function* asyncIterator() {
     yield 1
     yield 2
@@ -83,4 +87,164 @@ test('reader', async (t) => {
   t.alike(await reader.read(), { value: 1, done: false })
   t.alike(await reader.read(), { value: 2, done: false })
   t.alike(await reader.read(), { value: undefined, done: true })
+})
+
+test('pull', async (t) => {
+  t.plan(1)
+
+  let count = 0
+
+  const stream = new ReadableStream({
+    pull(controller) {
+      count !== 3 ? controller.enqueue(++count) : controller.close()
+    }
+  })
+
+  const read = []
+  for await (const value of stream) read.push(value)
+
+  t.alike(read, [1, 2, 3])
+})
+
+test('only trigger pull after start is finished', async (t) => {
+  t.plan(1)
+
+  let foo
+
+  new ReadableStream({
+    async start(controller) {
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      foo = 42
+    },
+    pull(controller) {
+      t.is(foo, 42)
+      controller.close()
+    }
+  })
+})
+
+test('CountQueuingStrategy', async (t) => {
+  t.plan(7)
+
+  let loop = 0
+
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        t.is(controller.desiredSize, 4)
+      },
+      async pull(controller) {
+        if (loop === 0) t.is(controller.desiredSize, 4)
+        if (loop === 1) t.is(controller.desiredSize, 3)
+
+        if (loop === 2) {
+          t.is(controller.desiredSize, 2)
+          await stream.getReader().read()
+          t.is(controller.desiredSize, 3)
+        }
+
+        if (loop === 3) t.is(controller.desiredSize, 2)
+        if (loop === 4) t.is(controller.desiredSize, 1)
+        if (loop === 5) t.fail()
+
+        controller.enqueue(loop++)
+      }
+    },
+    new CountQueuingStrategy({ highWaterMark: 4 })
+  )
+})
+
+test('custom high water mark', async (t) => {
+  t.plan(7)
+
+  let loop = 0
+
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        t.is(controller.desiredSize, 4)
+      },
+      async pull(controller) {
+        if (loop === 0) t.is(controller.desiredSize, 4)
+        if (loop === 1) t.is(controller.desiredSize, 3)
+
+        if (loop === 2) {
+          t.is(controller.desiredSize, 2)
+          await stream.getReader().read()
+          t.is(controller.desiredSize, 3)
+        }
+
+        if (loop === 3) t.is(controller.desiredSize, 2)
+        if (loop === 4) t.is(controller.desiredSize, 1)
+        if (loop === 5) t.fail()
+
+        controller.enqueue(loop++)
+      }
+    },
+    { highWaterMark: 4 }
+  )
+})
+
+test('ByteLengthQueuingStrategy', async (t) => {
+  t.plan(7)
+
+  let loop = 0
+
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        t.is(controller.desiredSize, 20)
+      },
+      async pull(controller) {
+        if (loop === 0) t.is(controller.desiredSize, 20)
+        if (loop === 1) t.is(controller.desiredSize, 15)
+
+        if (loop === 2) {
+          t.is(controller.desiredSize, 10)
+          await stream.getReader().read()
+          t.is(controller.desiredSize, 15)
+        }
+
+        if (loop === 3) t.is(controller.desiredSize, 10)
+        if (loop === 4) t.is(controller.desiredSize, 5)
+        if (loop === 5) t.fail()
+
+        loop++
+        controller.enqueue(Buffer.from('hello'))
+      }
+    },
+    new ByteLengthQueuingStrategy({ highWaterMark: 20 })
+  )
+})
+
+test('custom size function', async (t) => {
+  t.plan(7)
+
+  let loop = 0
+
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        t.is(controller.desiredSize, 20)
+      },
+      async pull(controller) {
+        if (loop === 0) t.is(controller.desiredSize, 20)
+        if (loop === 1) t.is(controller.desiredSize, 15)
+
+        if (loop === 2) {
+          t.is(controller.desiredSize, 10)
+          await stream.getReader().read()
+          t.is(controller.desiredSize, 15)
+        }
+
+        if (loop === 3) t.is(controller.desiredSize, 10)
+        if (loop === 4) t.is(controller.desiredSize, 5)
+        if (loop === 5) t.fail()
+
+        loop++
+        controller.enqueue('hello')
+      }
+    },
+    { highWaterMark: 20, size: (elem) => Buffer.from(elem).byteLength }
+  )
 })


### PR DESCRIPTION
My attempts to implement this so far have been quite a lame, but I think my progress on the tests is usable.

The biggest challenges IMO are: 
- Adapting the `streamx` backpressure to `ByteLengthQueuingStrategy` without breaking Hyrum's law.
- Get a `CountQueuingStrategy` implementation (which is sadly the default) to be reliable.

These challenges are similar for the `controller.desiredSize` field.

Another good case for a test is "If the (pull)  function returns a promise, then it will not be called again until that promise fulfills.".