### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -189,6 +189,14 @@ declare namespace Stream {
     Transform as PassThrough
   }
 
+  export function pipeline(streams: Stream[], done?: StreamCallback): Stream
+
+  export function pipeline(
+    ...args: [stream: Stream, ...streams: Stream[], done: StreamCallback]
+  ): Stream
+
+  export function pipeline(stream: Stream, ...streams: Stream[]): Stream
+
   export function finished(
     stream: Stream,
     opts: { cleanup?: boolean },

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,9 @@ interface Readable<M extends ReadableEvents = ReadableEvents>
   setEncoding(encoding: BufferEncoding): void
 }
 
-declare class Readable {
+declare class Readable<
+  M extends ReadableEvents = ReadableEvents
+> extends Stream<M> {
   constructor(opts?: ReadableOptions)
 
   static from(
@@ -128,7 +130,9 @@ interface Writable<M extends WritableEvents = WritableEvents>
   uncork(): void
 }
 
-declare class Writable {
+declare class Writable<
+  M extends WritableEvents = WritableEvents
+> extends Stream<M> {
   constructor(opts?: WritableOptions)
 
   static isBackpressured(ws: Writable): boolean
@@ -145,6 +149,8 @@ interface DuplexOptions<S extends Duplex = Duplex>
 interface Duplex<M extends DuplexEvents = DuplexEvents>
   extends Readable<M>,
     Writable<M> {}
+
+declare class Duplex<M extends DuplexEvents = DuplexEvents> extends Stream<M> {}
 
 interface TransformEvents extends DuplexEvents {}
 
@@ -165,7 +171,9 @@ interface Transform<M extends TransformEvents = TransformEvents>
   _flush(cb: StreamCallback): void
 }
 
-declare class Transform {
+declare class Transform<
+  M extends TransformEvents = TransformEvents
+> extends Duplex<M> {
   constructor(opts?: TransformOptions)
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,12 @@ declare class Transform<
   constructor(opts?: TransformOptions)
 }
 
+type Pipeline<S extends Writable> = [
+  src: Readable,
+  ...transforms: Duplex[],
+  dest: S
+]
+
 declare namespace Stream {
   export {
     Stream,
@@ -192,13 +198,16 @@ declare namespace Stream {
     Transform as PassThrough
   }
 
-  export function pipeline(streams: Stream[], done?: StreamCallback): Stream
+  export function pipeline<S extends Writable>(
+    streams: Pipeline<S>,
+    cb?: StreamCallback
+  ): S
 
-  export function pipeline(
-    ...args: [stream: Stream, ...streams: Stream[], done: StreamCallback]
-  ): Stream
+  export function pipeline<S extends Writable>(...args: [...Pipeline<S>]): S
 
-  export function pipeline(stream: Stream, ...streams: Stream[]): Stream
+  export function pipeline<S extends Writable>(
+    ...args: [...Pipeline<S>, cb: StreamCallback]
+  ): S
 
   export function finished(
     stream: Stream,

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,10 @@ declare class Readable<
   constructor(opts?: ReadableOptions)
 
   static from(
-    data: (Buffer | string)[] | AsyncIterable<Buffer | string>,
+    data:
+      | (Buffer | string)
+      | (Buffer | string)[]
+      | AsyncIterable<Buffer | string>,
     opts?: ReadableOptions
   ): Readable
 
@@ -203,7 +206,7 @@ declare namespace Stream {
     cb: StreamCallback
   ): () => void
 
-  export function finished(stream: Stream, cb: Stream): () => void
+  export function finished(stream: Stream, cb: StreamCallback): () => void
 
   export function isStream(stream: unknown): stream is Stream
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,7 +203,7 @@ declare namespace Stream {
     cb?: StreamCallback
   ): S
 
-  export function pipeline<S extends Writable>(...args: [...Pipeline<S>]): S
+  export function pipeline<S extends Writable>(...args: Pipeline<S>): S
 
   export function pipeline<S extends Writable>(
     ...args: [...Pipeline<S>, cb: StreamCallback]

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ interface Stream<M extends StreamEvents = StreamEvents>
   destroy(err?: Error | null): void
 }
 
+declare class Stream {}
+
 interface ReadableEvents extends StreamEvents {
   data: [data: Buffer | string]
   end: []

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,240 @@
+import EventEmitter from 'bare-events'
+import Buffer, { BufferEncoding } from 'bare-buffer'
+
+// duplicated from 'bare-events'
+declare interface EventMap {
+  [event: string | symbol]: unknown[]
+}
+
+type StreamOptions = {
+  destroy?: Stream['_destroy']
+  eagerOpen?: boolean
+  open?: Stream['_open']
+  predestroy?: Stream['_predestroy']
+  signal?: AbortSignal
+}
+
+declare interface Stream<M extends EventMap = EventMap>
+  extends EventEmitter<M> {
+  _open(cb: (err?: Error | null) => void): void
+  _destroy: (
+    this: this,
+    err: Error | null,
+    cb: (err?: Error | null) => void
+  ) => void
+  _predestroy(): void
+
+  get readable(): boolean
+  get writable(): boolean
+  get destroyed(): boolean
+  get destroying(): boolean
+
+  destroy(err?: Error | null): void
+}
+
+declare class Stream {
+  constructor(opts?: StreamOptions)
+}
+
+type ReadableOptions = {
+  byteLength?: (data: unknown) => number
+  byteLengthReadable?: (data: unknown) => number
+  encoding?: BufferEncoding
+  highWaterMark?: number
+  map?: (data: unknown) => unknown
+  mapReadable?: (data: unknown) => unknown
+  read?: Readable['_read']
+} & StreamOptions
+
+declare interface Readable<T = Buffer | string>
+  extends Stream<{
+    data: [data: T | null]
+    close: []
+    end: []
+    error: [err: Error]
+    readable: []
+    piping: [dest: unknown]
+  }> {
+  _read(this: this, size: number): void
+
+  push(chunk: T | null, encoding?: BufferEncoding): boolean
+
+  unshift(chunk: T | null, encoding?: BufferEncoding): boolean
+
+  read(): T | null
+
+  resume(): this
+  pause(): this
+
+  pipe<A extends Writable | Duplex>(dest: A, cb?: (err: Error) => void): A
+
+  setEncoding(encoding: BufferEncoding): void
+
+  [Symbol.asyncIterator](): AsyncIterator<T>
+}
+
+declare class Readable {
+  static from(data: unknown | unknown[], opts?: ReadableOptions): Readable
+
+  static isBackpressured(rs: Readable): boolean
+  static isPaused(rs: Readable): boolean
+
+  constructor(opts?: ReadableOptions)
+}
+
+type WritableOptions = {
+  final?: Writable['_final']
+  mapWritable?: (data: unknown) => unknown
+  write?: Writable['_write']
+  writev?: Writable['_writev']
+} & StreamOptions
+
+declare interface Writable<T = Buffer | string>
+  extends Stream<{
+    drain: []
+    finish: []
+    close: []
+    error: [err: Error]
+    pipe: [src: Readable]
+  }> {
+  readonly destroyed: boolean
+
+  _writev(this: this, batch: T[], cb: (err?: Error | null) => void): void
+  _write(
+    this: this,
+    data: T,
+    encoding: BufferEncoding,
+    cb: (err?: Error | null) => void
+  ): void
+  _final(this: this, cb: (err?: Error | null) => void): void
+
+  write(chunk: T, encoding?: BufferEncoding, cb?: () => void): boolean
+  write(chunk: T, cb?: () => void): boolean
+
+  end(chunk: T, encoding?: BufferEncoding, cb?: () => void): this
+  end(chunk: T, cb?: () => void): this
+  end(cb?: () => void): this
+
+  cork(): void
+  uncork(): void
+}
+
+declare class Writable {
+  static isBackpressured(ws: Writable): Promise<boolean>
+  static drained(ws: Writable): Promise<boolean>
+
+  constructor(opts?: WritableOptions)
+}
+
+type DuplexOptions = ReadableOptions & WritableOptions
+
+declare interface Duplex<T = Buffer | string>
+  extends Stream<{
+    close: []
+    data: [data: T | null]
+    drain: []
+    end: []
+    error: [err: Error]
+    finish: []
+    pipe: [src: Readable]
+    piping: [dest: unknown]
+    readable: []
+  }> {
+  _read(this: this, size: number): void
+  _writev(this: this, batch: T[], cb: (err?: Error | null) => void): void
+  _write(this: this, data: T, cb: (err?: Error | null) => void): void
+  _final(this: this, cb: (err?: Error | null) => void): void
+
+  write(chunk: T, encoding?: BufferEncoding, cb?: () => void): boolean
+  write(chunk: T, cb?: () => void): boolean
+
+  end(chunk: T, encoding?: BufferEncoding, cb?: () => void): this
+  end(chunk: T, cb?: () => void): this
+  end(cb?: () => void): this
+
+  push(chunk: T | null, encoding?: BufferEncoding): boolean
+  unshift(chunk: T | null, encoding?: BufferEncoding): boolean
+
+  read(): T | null
+
+  resume(): this
+  pause(): this
+
+  pipe<A extends Stream>(dest: A, cb?: (err: Error) => void): A
+
+  setEncoding(encoding: BufferEncoding): void
+
+  cork(): void
+  uncork(): void
+
+  [Symbol.asyncIterator](): AsyncIterator<T>
+}
+
+declare class Duplex {
+  constructor(opts?: DuplexOptions)
+}
+
+type TransformOptions = {
+  flush?: Transform['_flush']
+  transform?: Transform['_transform']
+} & DuplexOptions
+
+declare interface Transform<T = Buffer | string> extends Duplex {
+  _transform(
+    this: this,
+    data: T,
+    encoding: BufferEncoding,
+    cb: (err?: Error | null) => void
+  ): void
+  _flush(cb: (this: this, err: Error | null) => void): void
+}
+
+declare class Transform {
+  constructor(opts?: TransformOptions)
+}
+
+declare class Pipeline {
+  constructor(src: Stream, dst: Stream, cb: (err?: Error | null) => void)
+
+  finished(): void
+
+  done(stream: Stream, err: Error): void
+}
+
+declare namespace Stream {
+  export {
+    Pipeline,
+    Stream,
+    Readable,
+    Writable,
+    Duplex,
+    Transform,
+    Transform as PassThrough
+  }
+
+  export function finished(
+    stream: Stream,
+    opts: { cleanup?: boolean },
+    cb: (err?: Error | null) => void
+  ): () => void
+
+  export function finished(
+    stream: Stream,
+    cb: (err?: Error | null) => void
+  ): () => void
+
+  export function isStream(stream: unknown): stream is Stream
+
+  export function isEnded(stream: Stream): boolean
+
+  export function isFinished(stream: Stream): boolean
+
+  export function isDisturbed(stream: Stream): boolean
+
+  export function getStreamError(
+    stream: Stream,
+    opts?: { all?: boolean }
+  ): Error | null
+}
+
+export = Stream

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,7 +150,9 @@ interface Duplex<M extends DuplexEvents = DuplexEvents>
   extends Readable<M>,
     Writable<M> {}
 
-declare class Duplex<M extends DuplexEvents = DuplexEvents> extends Stream<M> {}
+declare class Duplex<M extends DuplexEvents = DuplexEvents> extends Stream<M> {
+  constructor(opts?: DuplexOptions)
+}
 
 interface TransformEvents extends DuplexEvents {}
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare class Readable {
 
   static from(
     data: (Buffer | string)[] | AsyncIterable<Buffer | string>,
-    opts?: ReadableOptions<Readable>
+    opts?: ReadableOptions
   ): Readable
 
   static isBackpressured(rs: Readable): boolean

--- a/index.js
+++ b/index.js
@@ -17,7 +17,13 @@ exports.Stream = exports
 
 exports.Readable = class Readable extends stream.Readable {
   constructor(opts = {}) {
-    super(opts)
+    super({
+      ...opts,
+      byteLength: null,
+      byteLengthReadable: null,
+      map: null,
+      mapReadable: null
+    })
 
     if (this._construct) this._open = this._construct
 
@@ -49,7 +55,13 @@ exports.Readable = class Readable extends stream.Readable {
 
 exports.Writable = class Writable extends stream.Writable {
   constructor(opts = {}) {
-    super({ ...opts, byteLengthWritable })
+    super({
+      ...opts,
+      byteLength: null,
+      byteLengthWritable,
+      map: null,
+      mapWritable: null
+    })
 
     if (this._construct) this._open = this._construct
 
@@ -77,7 +89,7 @@ exports.Writable = class Writable extends stream.Writable {
 
     const result = super.write({ chunk, encoding })
 
-    if (cb) stream.Writable.drained(this).then(cb, cb)
+    if (cb) stream.Writable.drained(this).then(() => cb(null), cb)
 
     return result
   }
@@ -103,7 +115,7 @@ exports.Writable = class Writable extends stream.Writable {
         ? super.end({ chunk, encoding })
         : super.end()
 
-    if (cb) this.once('end', cb)
+    if (cb) this.once('end', () => cb(null))
 
     return result
   }
@@ -111,7 +123,15 @@ exports.Writable = class Writable extends stream.Writable {
 
 exports.Duplex = class Duplex extends stream.Duplex {
   constructor(opts = {}) {
-    super({ ...opts, byteLengthWritable })
+    super({
+      ...opts,
+      byteLength: null,
+      byteLengthReadable: null,
+      byteLengthWritable,
+      map: null,
+      mapReadable: null,
+      mapWritable: null
+    })
 
     if (this._construct) this._open = this._construct
 
@@ -159,7 +179,7 @@ exports.Duplex = class Duplex extends stream.Duplex {
 
     const result = super.write({ chunk, encoding })
 
-    if (cb) stream.Writable.drained(this).then(cb, cb)
+    if (cb) stream.Writable.drained(this).then(() => cb(null), cb)
 
     return result
   }
@@ -185,7 +205,7 @@ exports.Duplex = class Duplex extends stream.Duplex {
         ? super.end({ chunk, encoding })
         : super.end()
 
-    if (cb) this.once('end', cb)
+    if (cb) this.once('end', () => cb(null))
 
     return result
   }
@@ -193,7 +213,15 @@ exports.Duplex = class Duplex extends stream.Duplex {
 
 exports.Transform = class Transform extends stream.Transform {
   constructor(opts = {}) {
-    super({ ...opts, byteLengthWritable })
+    super({
+      ...opts,
+      byteLength: null,
+      byteLengthReadable: null,
+      byteLengthWritable,
+      map: null,
+      mapReadable: null,
+      mapWritable: null
+    })
 
     if (this._transform !== stream.Transform.prototype._transform) {
       this._transform = transform.bind(this, this._transform)
@@ -233,7 +261,7 @@ exports.Transform = class Transform extends stream.Transform {
 
     const result = super.write({ chunk, encoding })
 
-    if (cb) stream.Writable.drained(this).then(cb, cb)
+    if (cb) stream.Writable.drained(this).then(() => cb(null), cb)
 
     return result
   }
@@ -259,7 +287,7 @@ exports.Transform = class Transform extends stream.Transform {
         ? super.end({ chunk, encoding })
         : super.end()
 
-    if (cb) this.once('end', cb)
+    if (cb) this.once('end', () => cb(null))
 
     return result
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "global.js"
   ],
   "scripts": {
-    "test": "prettier . --check && bare test/all.js"
+    "test": "prettier . --check && bare test.js"
   },
   "repository": {
     "type": "git",
@@ -36,8 +36,8 @@
     "streamx": "^2.21.0"
   },
   "devDependencies": {
-    "bare-buffer": "^2.7.1",
-    "bare-events": "^2.5.3",
+    "bare-buffer": "^3.0.0",
+    "bare-events": "^2.5.4",
     "brittle": "^3.5.2",
     "prettier": "^3.3.3",
     "prettier-config-standard": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "2.6.1",
   "description": "Streaming data for JavaScript",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
     "./package": "./package.json",
     "./promises": "./promises.js",
     "./web": "./web.js",
@@ -11,6 +14,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "promises.js",
     "web.js",
     "global.js"
@@ -32,8 +36,14 @@
     "streamx": "^2.21.0"
   },
   "devDependencies": {
+    "bare-buffer": "^2.7.1",
+    "bare-events": "^2.5.3",
     "brittle": "^3.5.2",
     "prettier": "^3.3.3",
     "prettier-config-standard": "^7.0.0"
+  },
+  "peerDependencies": {
+    "bare-buffer": "*",
+    "bare-events": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,2 @@
+require('./test/basic')
+require('./test/web')

--- a/test/all.js
+++ b/test/all.js
@@ -1,2 +1,0 @@
-require('./basic')
-require('./web')


### PR DESCRIPTION
The `this` overhead at lines at: `_read(this: this, size: number): void` are a workaround to correct the 'this' value inside functions passed on constructor like:

```js
const stream = new Readable({
  read(size) {
    t.is(this, stream) // in this case, 'this' was ReadableOptions 
  }
})
```