### PR TITLE
Complete WritableStream API

### DIFF
--- a/test/web.js
+++ b/test/web.js
@@ -130,7 +130,7 @@ test('ReadableStream - locked', async (t) => {
 
   reader.releaseLock()
 
-  await t.exception.all(async () => reader.closed, 'called releaseLock before stream closure')
+  await t.exception.all(reader.closed, 'called releaseLock before stream closure')
 
   t.is(stream.locked, false)
 })
@@ -324,7 +324,7 @@ test('ReadableStream - custom size function', async (t) => {
   reader.read()
 })
 
-test('WritableStream - writer', async (t) => {
+test('WritableStream', async (t) => {
   t.plan(6)
 
   const stream = new WritableStream({
@@ -347,6 +347,20 @@ test('WritableStream - writer', async (t) => {
   await writer.write('foo')
 
   await t.execution(writer.close(), 'writer closed')
+})
+
+test('WritableStream - error', async (t) => {
+  t.plan(1)
+
+  const stream = new WritableStream({
+    start(controller) {
+      controller.error('boom!')
+    }
+  })
+
+  const writer = stream.getWriter()
+
+  await t.exception(writer.write('foo'), /boom!/)
 })
 
 test('WritableStream - close', async (t) => {

--- a/test/web.js
+++ b/test/web.js
@@ -414,6 +414,22 @@ test('WritableStream - writer.abort', async (t) => {
   await t.execution(writer.abort('reason'))
 })
 
+test('WritableStream - locked', async (t) => {
+  t.plan(2)
+
+  const stream = new WritableStream()
+
+  const writer = stream.getWriter()
+
+  t.is(stream.locked, true)
+
+  writer.releaseLock()
+
+  // await t.exception.all(reader.closed, 'called releaseLock before stream closure')
+
+  t.is(stream.locked, false)
+})
+
 test('ReadableStream.pipeTo(WritableStream)', async (t) => {
   t.plan(1)
 

--- a/test/web.js
+++ b/test/web.js
@@ -445,7 +445,7 @@ test('WritableStream - ready', async (t) => {
   t.ok(writer.ready)
   await t.execution(writer.ready)
 
-  writer.abort('reason')
+  writer.abort()
 
   await t.exception(writer.ready)
 })

--- a/test/web.js
+++ b/test/web.js
@@ -50,11 +50,25 @@ test('ReadableStream - cancel', async (t) => {
 
   const stream = new ReadableStream({
     cancel(reason) {
-      t.is(reason, 'I am bored')
+      t.is(reason, 'reason')
     }
   })
 
-  await t.execution(stream.cancel('I am bored'))
+  await t.execution(stream.cancel('reason'))
+})
+
+test('ReadableStream - reader.cancel', async (t) => {
+  t.plan(2)
+
+  const stream = new ReadableStream({
+    cancel(reason) {
+      t.is(reason, 'reason')
+    }
+  })
+
+  const reader = stream.getReader()
+
+  await t.execution(reader.cancel('reason'))
 })
 
 test('ReadableStream - from', async (t) => {
@@ -355,6 +369,9 @@ test('WritableStream - error', async (t) => {
   const stream = new WritableStream({
     start(controller) {
       controller.error('boom!')
+    },
+    abort(reason) {
+      // t.fail()
     }
   })
 
@@ -369,6 +386,32 @@ test('WritableStream - close', async (t) => {
   const stream = new WritableStream()
 
   await t.execution(stream.close())
+})
+
+test('WritableStream - abort', async (t) => {
+  t.plan(2)
+
+  const stream = new WritableStream({
+    abort(reason) {
+      t.is(reason, 'reason')
+    }
+  })
+
+  await t.execution(stream.abort('reason'))
+})
+
+test('WritableStream - writer.abort', async (t) => {
+  t.plan(2)
+
+  const stream = new WritableStream({
+    abort(reason) {
+      t.is(reason, 'reason')
+    }
+  })
+
+  const writer = stream.getWriter()
+
+  await t.execution(writer.abort('reason'))
 })
 
 test('ReadableStream.pipeTo(WritableStream)', async (t) => {

--- a/test/web.js
+++ b/test/web.js
@@ -94,7 +94,7 @@ test('ReadableStream - from', async (t) => {
 })
 
 test('ReadableStream - reader', async (t) => {
-  t.plan(6)
+  t.plan(7)
 
   const stream = new ReadableStream({
     start(controller) {
@@ -107,6 +107,7 @@ test('ReadableStream - reader', async (t) => {
   const reader = stream.getReader()
 
   t.exception.all(() => stream.getReader(), /ReadableStream is locked/)
+  await t.exception.all(stream.cancel(), /ReadableStream is locked/)
 
   t.alike(await reader.read(), { value: 1, done: false })
   t.alike(await reader.read(), { value: 2, done: false })
@@ -144,7 +145,7 @@ test('ReadableStream - locked', async (t) => {
 
   reader.releaseLock()
 
-  await t.exception(reader.closed, 'called releaseLock before stream closure')
+  await t.exception.all(reader.closed, /released/)
 
   t.is(stream.locked, false)
 })
@@ -339,7 +340,7 @@ test('ReadableStream - custom size function', async (t) => {
 })
 
 test('WritableStream', async (t) => {
-  t.plan(9)
+  t.plan(11)
 
   const stream = new WritableStream({
     start(controller) {
@@ -357,6 +358,8 @@ test('WritableStream', async (t) => {
   const writer = stream.getWriter()
 
   t.exception.all(() => stream.getWriter(), /WritableStream is locked/)
+  await t.exception.all(stream.abort(), /WritableStream is locked/)
+  await t.exception.all(stream.close(), /WritableStream is locked/)
 
   t.is(writer.desiredSize, 1)
 
@@ -430,7 +433,7 @@ test('WritableStream - locked', async (t) => {
 
   writer.releaseLock()
 
-  await t.exception(writer.closed, 'called releaseLock before stream closure')
+  await t.exception.all(writer.closed, /released/)
 
   t.is(stream.locked, false)
 })

--- a/test/web.js
+++ b/test/web.js
@@ -435,6 +435,21 @@ test('WritableStream - locked', async (t) => {
   t.is(stream.locked, false)
 })
 
+test('WritableStream - ready', async (t) => {
+  t.plan(3)
+
+  const stream = new WritableStream()
+
+  const writer = stream.getWriter()
+
+  t.ok(writer.ready)
+  await t.execution(writer.ready)
+
+  writer.abort('reason')
+
+  await t.exception(writer.ready)
+})
+
 test('ReadableStream.pipeTo(WritableStream)', async (t) => {
   t.plan(1)
 

--- a/test/web.js
+++ b/test/web.js
@@ -144,7 +144,7 @@ test('ReadableStream - locked', async (t) => {
 
   reader.releaseLock()
 
-  await t.exception.all(reader.closed, 'called releaseLock before stream closure')
+  await t.exception(reader.closed, 'called releaseLock before stream closure')
 
   t.is(stream.locked, false)
 })
@@ -339,7 +339,7 @@ test('ReadableStream - custom size function', async (t) => {
 })
 
 test('WritableStream', async (t) => {
-  t.plan(6)
+  t.plan(9)
 
   const stream = new WritableStream({
     start(controller) {
@@ -356,11 +356,16 @@ test('WritableStream', async (t) => {
 
   const writer = stream.getWriter()
 
+  t.exception.all(() => stream.getWriter(), /WritableStream is locked/)
+
   t.is(writer.desiredSize, 1)
 
   await writer.write('foo')
 
   await t.execution(writer.close(), 'writer closed')
+
+  t.ok(writer.closed)
+  await t.execution(writer.closed, 'writer closed getter')
 })
 
 test('WritableStream - error', async (t) => {
@@ -415,7 +420,7 @@ test('WritableStream - writer.abort', async (t) => {
 })
 
 test('WritableStream - locked', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const stream = new WritableStream()
 
@@ -425,7 +430,7 @@ test('WritableStream - locked', async (t) => {
 
   writer.releaseLock()
 
-  // await t.exception.all(reader.closed, 'called releaseLock before stream closure')
+  await t.exception(writer.closed, 'called releaseLock before stream closure')
 
   t.is(stream.locked, false)
 })

--- a/web.js
+++ b/web.js
@@ -268,6 +268,10 @@ exports.WritableStreamDefaultWriter = class WritableStreamDefaultWriter {
   }
 
   async write(chunk) {
+    const err = getStreamError(this._stream)
+
+    if (err) return Promise.reject(err)
+
     this._stream.write(chunk)
 
     await Writable.drained(this._stream)
@@ -288,6 +292,10 @@ exports.WritableStreamDefaultWriter = class WritableStreamDefaultWriter {
 exports.WritableStreamDefaultController = class WritableStreamDefaultController {
   constructor(stream) {
     this._stream = stream._stream
+  }
+
+  error(err) {
+    this._stream.destroy(err)
   }
 }
 

--- a/web.js
+++ b/web.js
@@ -79,7 +79,7 @@ exports.ReadableStreamDefaultReader = class ReadableStreamDefaultReader {
     this.stream._releaseLock()
   }
 
-  cancel(reason) {
+  cancel(reason = 'ReadableStream was cancelled') {
     return this.stream.cancel(reason)
   }
 }
@@ -160,7 +160,7 @@ class ReadableStream {
     return this._reader
   }
 
-  cancel(reason) {
+  cancel(reason = 'ReadableStream was cancelled') {
     if (this._stream.destroyed) return Promise.resolve()
 
     return new Promise((resolve) => this._stream.once('close', resolve).destroy(reason))
@@ -326,7 +326,7 @@ exports.WritableStreamDefaultWriter = class WritableStreamDefaultWriter {
     return new Promise((resolve) => stream.once('close', resolve).end())
   }
 
-  abort(reason) {
+  abort(reason = 'WritableStream was aborted') {
     return this.stream.abort(reason)
   }
 }
@@ -399,7 +399,7 @@ class WritableStream {
     return this._writer
   }
 
-  abort(reason) {
+  abort(reason = 'WritableStream was aborted') {
     if (this._stream.destroyed) return Promise.resolve()
 
     return new Promise((resolve) => this._stream.once('close', resolve).destroy(reason))

--- a/web.js
+++ b/web.js
@@ -293,6 +293,14 @@ exports.WritableStreamDefaultWriter = class WritableStreamDefaultWriter {
     return this._closed.promise
   }
 
+  get ready() {
+    const stream = this.stream._stream
+
+    if (getStreamError(stream)) return Promise.reject()
+
+    return Writable.drained(stream).then()
+  }
+
   async write(chunk) {
     const stream = this.stream._stream
 


### PR DESCRIPTION
Some changes were added to ReadableStream classes and tests for symmetry.

I left a commented `t.fail()` assertion at the `WritableStream - error` unit test to keep registered a small incompatibility with the [specs](https://streams.spec.whatwg.org/#readable-stream-error) as `WritableStreamDefaultController.error` does not have a step to trigger any `abort` callback.